### PR TITLE
Implements a safer method of deleting directories

### DIFF
--- a/unwrap.plugin.zsh
+++ b/unwrap.plugin.zsh
@@ -49,10 +49,16 @@ unwrap() {
       echo "\n✅ \033[38;5;118mFiles moved, removing directory"
       cd ..
       if rmdir -v "$this_dir" 2>/dev/null; then
-        echo "\n✅ \033[38;5;118mEmpty directory removed."
+        echo "\n✅ \033[38;5;118mEmpty directory removed. Process completed."
       else
-        echo "\n⚠️ \033[38;5;214mDirectory not empty, using rm -rf."
-        command rm -rf "$this_dir"
+        echo "\n⚠️ \033[38;5;214mDirectory not empty, Something went wrong.\n"
+        echo -n "\033[38;5;024mDo you wish to force delete the folder including the files? (y/N)\n\033[0m";
+        read check;
+        if [[ $check == "y" ]]; then
+          echo "\033[38;5;124mRemoving directory forcefully."
+          command rm -rf "$this_dir"
+        fi
+        echo "\n \033[38;5;118mDirectory not removed. Process aborted."
       fi
     fi
     return 1

--- a/unwrap.plugin.zsh
+++ b/unwrap.plugin.zsh
@@ -3,7 +3,7 @@
 # directory and then deletes the current directory
 unwrap() {
   local this_dir=`basename $PWD`;
-  local sys_dirs=`ls /`;
+  local sys_dirs=`command ls /`;
   local in_sys_dir=`echo ${sys_dirs[@]} | grep -o $this_dir | wc -w`;
   
   if [ -e "$HOME/.unwrap" ]; then
@@ -48,7 +48,12 @@ unwrap() {
       fi
       echo "\n✅ \033[38;5;118mFiles moved, removing directory"
       cd ..
-      rm -rf $this_dir
+      if rmdir -v "$this_dir" 2>/dev/null; then
+        echo "\n✅ \033[38;5;118mEmpty directory removed."
+      else
+        echo "\n⚠️ \033[38;5;214mDirectory not empty, using rm -rf."
+        command rm -rf "$this_dir"
+      fi
     fi
     return 1
   fi


### PR DESCRIPTION
Implements suggesting improvement to plugin from @joh6nn after the bug reported in #3.

This now prevents potential user `ls` aliases from interfering with the command.

It also adds `rmdir` as a 'first-try' to delete a folder and IF any files are left over, it will fail and offer the user an option to force-delete the folder and files.

Closes #3 